### PR TITLE
Fix build script for BSD/MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # Local History for Visual Studio Code
 .history/
+
+# Files created after build
+Linux/dotnet-spark/HelloSpark
+Linux/spark/sbin

--- a/Linux/build.sh
+++ b/Linux/build.sh
@@ -7,27 +7,38 @@ DOTNET_SPARK_VERSION=0.11.0
 SPARK_VERSION=2.4.5
 SHORTVER="${SPARK_VERSION:0:3}"
 
+replace_text_with_sed()
+{
+    filename=$1
+    original_text=$2
+    final_text=$3
+
+    sh -c 'sed -i.bak "s/$1/$2/g" "$3" && rm "$3.bak"' _ "$original_text" "$final_text" $filename
+}
+
 build_dotnet-sdk-linux()
 {
     cd dotnet-sdk
     docker build --build-arg DOTNET_CORE_VERSION=$DOTNET_CORE_VERSION -t 3rdman/dotnet-sdk-linux:$DOTNET_CORE_VERSION .
     cd -
-} 
+}
 
 build_dotnet-spark-base-linux()
 {
     cd dotnet-spark
     rm -rf HelloSpark
     cp -r templates/HelloSpark ./HelloSpark
-    sed -i "s/<TargetFramework><\/TargetFramework>/<TargetFramework>netcoreapp${DOTNET_CORE_VERSION}<\/TargetFramework>/g" HelloSpark/HelloSpark.csproj
-    sed -i "s/PackageReference Include=\"Microsoft.Spark\" Version=\"\"/PackageReference Include=\"Microsoft.Spark\" Version=\"${DOTNET_SPARK_VERSION}\"/g" HelloSpark/HelloSpark.csproj
-    
-    sed -i "s/netcoreappX.X/netcoreapp${DOTNET_CORE_VERSION}/g" HelloSpark/README.txt
-    sed -i "s/spark-X.X.X/spark-${SHORTVER}.x/g" HelloSpark/README.txt
-    sed -i "s/spark-${SHORTVER}.x-X.X.X.jar/spark-${SHORTVER}.x-${DOTNET_SPARK_VERSION}.jar/g" HelloSpark/README.txt
+
+    replace_text_with_sed HelloSpark/HelloSpark.csproj "<TargetFramework><\/TargetFramework>" "<TargetFramework>netcoreapp${DOTNET_CORE_VERSION}<\/TargetFramework>"
+    replace_text_with_sed HelloSpark/HelloSpark.csproj "PackageReference Include=\"Microsoft.Spark\" Version=\"\"" "PackageReference Include=\"Microsoft.Spark\" Version=\"${DOTNET_SPARK_VERSION}\""
+
+    replace_text_with_sed HelloSpark/README.txt "netcoreappX.X" "netcoreapp${DOTNET_CORE_VERSION}"
+    replace_text_with_sed HelloSpark/README.txt "spark-X.X.X" "spark-${SHORTVER}.x"
+    replace_text_with_sed HelloSpark/README.txt "spark-${SHORTVER}.x-X.X.X.jar" "spark-${SHORTVER}.x-${DOTNET_SPARK_VERSION}.jar"
+
     docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-base-linux .
     cd -
-} 
+}
 
 build_dotnet-spark-linux()
 {
@@ -35,11 +46,11 @@ build_dotnet-spark-linux()
     rm -rf sbin
     cp -r templates/sbin ./sbin
 
-    sed -i "s/microsoft-spark-X.X.X/microsoft-spark-${SHORTVER}.x/g" sbin/start-spark-debug.sh
+    replace_text_with_sed sbin/start-spark-debug.sh "microsoft-spark-X.X.X" "microsoft-spark-${SHORTVER}.x"
     docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION --build-arg SPARK_VERSION=$SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-spark-$SPARK_VERSION-linux .
     cd -
 }
- 
+
 build_dotnet-sdk-linux
 build_dotnet-spark-base-linux
 build_dotnet-spark-linux

--- a/Linux/dotnet-sdk/Dockerfile
+++ b/Linux/dotnet-sdk/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-get update \
     && apt-get install -y apt-transport-https \
     && apt-get update \
     && apt-get install -y dotnet-sdk-$DOTNET_CORE_VERSION \
-    && apt-get autoremove -y --purge \ 
+    && apt-get autoremove -y --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf packages-microsoft-prod.deb
-    

--- a/Linux/dotnet-spark/Dockerfile
+++ b/Linux/dotnet-spark/Dockerfile
@@ -7,16 +7,16 @@ ENV DOTNET_WORKER_DIR=/dotnet/Microsoft.Spark.Worker-${DOTNET_SPARK_VERSION}
 
 RUN mkdir -p /dotnet/HelloSpark \
     && mkdir -p /dotnet/Debug/netcoreapp${DOTNET_CORE_VERSION} \
-    && mkdir /tempdata \  
-    && chmod 777 /tempdata \ 
-    && wget https://github.com/dotnet/spark/releases/download/v${DOTNET_SPARK_VERSION}/Microsoft.Spark.Worker.netcoreapp${DOTNET_CORE_VERSION}.linux-x64-${DOTNET_SPARK_VERSION}.tar.gz \ 
-    && tar -xvzf Microsoft.Spark.Worker.netcoreapp${DOTNET_CORE_VERSION}.linux-x64-${DOTNET_SPARK_VERSION}.tar.gz \ 
+    && mkdir /tempdata \
+    && chmod 777 /tempdata \
+    && wget https://github.com/dotnet/spark/releases/download/v${DOTNET_SPARK_VERSION}/Microsoft.Spark.Worker.netcoreapp${DOTNET_CORE_VERSION}.linux-x64-${DOTNET_SPARK_VERSION}.tar.gz \
+    && tar -xvzf Microsoft.Spark.Worker.netcoreapp${DOTNET_CORE_VERSION}.linux-x64-${DOTNET_SPARK_VERSION}.tar.gz \
     && mv Microsoft.Spark.Worker-${DOTNET_SPARK_VERSION} /dotnet/ \
     && cp /dotnet/Microsoft.Spark.Worker-${DOTNET_SPARK_VERSION}/Microsoft.Spark.Worker /dotnet/Microsoft.Spark.Worker-${DOTNET_SPARK_VERSION}/Microsoft.Spark.Worker.exe \
     && chmod 755 /dotnet/Microsoft.Spark.Worker-${DOTNET_SPARK_VERSION}/Microsoft.Spark.Worker \
     && chmod 755 /dotnet/Microsoft.Spark.Worker-${DOTNET_SPARK_VERSION}/Microsoft.Spark.Worker.exe \
-    && rm Microsoft.Spark.Worker.netcoreapp${DOTNET_CORE_VERSION}.linux-x64-${DOTNET_SPARK_VERSION}.tar.gz 
-    
+    && rm Microsoft.Spark.Worker.netcoreapp${DOTNET_CORE_VERSION}.linux-x64-${DOTNET_SPARK_VERSION}.tar.gz
+
 COPY HelloSpark /dotnet/HelloSpark
 
 RUN cd /dotnet/HelloSpark \

--- a/Linux/spark/Dockerfile
+++ b/Linux/spark/Dockerfile
@@ -22,7 +22,7 @@ ENV HADOOP_VERSION=2.7
 ENV PATH="${SPARK_HOME}/bin:${DOTNET_WORKER_DIR}:${PATH}"
 
 COPY sbin /sbin/
-COPY supervisor.conf /etc/supervisor.conf 
+COPY supervisor.conf /etc/supervisor.conf
 
 RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
     && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \


### PR DESCRIPTION
The build script uses the `sed` command, which has a different
implementation for GNU and for BSD/MacOS.

This commit also deletes useless trailing spaces and add build files to
.gitignore. Those files are for build purposes only, thus they do not
need to be tracked.

Please read more at:

https://stackoverflow.com/questions/16745988/sed-command-with-i-option-in-place-editing-works-fine-on-ubuntu-but-not-mac