### PR TITLE
Add proxy support on build script

### DIFF
--- a/Linux/build.sh
+++ b/Linux/build.sh
@@ -3,8 +3,9 @@
 set -e
 
 DOTNET_CORE_VERSION=3.1
-DOTNET_SPARK_VERSION=0.11.0
+DOTNET_SPARK_VERSION=0.12.1
 SPARK_VERSION=2.4.5
+PROXY=""
 SHORTVER="${SPARK_VERSION:0:3}"
 
 replace_text_with_sed()
@@ -19,7 +20,16 @@ replace_text_with_sed()
 build_dotnet-sdk-linux()
 {
     cd dotnet-sdk
-    docker build --build-arg DOTNET_CORE_VERSION=$DOTNET_CORE_VERSION -t 3rdman/dotnet-sdk-linux:$DOTNET_CORE_VERSION .
+    if [ -z "$PROXY" ]
+    then
+        docker build --build-arg DOTNET_CORE_VERSION=$DOTNET_CORE_VERSION -t 3rdman/dotnet-sdk-linux:$DOTNET_CORE_VERSION .
+    else
+        docker build --build-arg DOTNET_CORE_VERSION=$DOTNET_CORE_VERSION -t 3rdman/dotnet-sdk-linux:$DOTNET_CORE_VERSION . \
+            --build-arg http_proxy=$PROXY \
+            --build-arg https_proxy=$PROXY \
+            --build-arg HTTP_PROXY=$PROXY \
+            --build-arg HTTPS_PROXY=$PROXY
+    fi
     cd -
 }
 
@@ -36,7 +46,16 @@ build_dotnet-spark-base-linux()
     replace_text_with_sed HelloSpark/README.txt "spark-X.X.X" "spark-${SHORTVER}.x"
     replace_text_with_sed HelloSpark/README.txt "spark-${SHORTVER}.x-X.X.X.jar" "spark-${SHORTVER}.x-${DOTNET_SPARK_VERSION}.jar"
 
-    docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-base-linux .
+    if [ -z "$PROXY" ]
+    then
+        docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-base-linux .
+    else
+        docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-base-linux . \
+            --build-arg http_proxy=$PROXY \
+            --build-arg https_proxy=$PROXY \
+            --build-arg HTTP_PROXY=$PROXY \
+            --build-arg HTTPS_PROXY=$PROXY
+    fi
     cd -
 }
 
@@ -47,7 +66,16 @@ build_dotnet-spark-linux()
     cp -r templates/sbin ./sbin
 
     replace_text_with_sed sbin/start-spark-debug.sh "microsoft-spark-X.X.X" "microsoft-spark-${SHORTVER}.x"
-    docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION --build-arg SPARK_VERSION=$SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-spark-$SPARK_VERSION-linux .
+    if [ -z "$PROXY" ]
+    then
+        docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION --build-arg SPARK_VERSION=$SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-spark-$SPARK_VERSION-linux .
+    else
+        docker build --build-arg DOTNET_SPARK_VERSION=$DOTNET_SPARK_VERSION --build-arg SPARK_VERSION=$SPARK_VERSION -t 3rdman/dotnet-spark:$DOTNET_SPARK_VERSION-spark-$SPARK_VERSION-linux . \
+            --build-arg http_proxy=$PROXY \
+            --build-arg https_proxy=$PROXY \
+            --build-arg HTTP_PROXY=$PROXY \
+            --build-arg HTTPS_PROXY=$PROXY
+    fi
     cd -
 }
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ More details about using the image are available at [3rdman.de](https://3rdman.d
 
 ## Building
 
-To build the image just run the [build.sh](Linux/build.sh) bash script. You can adjust the related variables in the script to build for different versions of .NET core, .NET for Apache Spark and/or Apache Spark.
+To build the image just run the [build.sh](Linux/build.sh) bash script. You can adjust the related variables in the script to build for different versions of .NET core, .NET for Apache Spark and/or Apache Spark, as well as a proxy if you are behind one (please note that the `PROXY` variable will set for both HTTP and HTTPS — we might change that in the future).
 
 
 ```bash
 DOTNET_CORE_VERSION=3.1
-DOTNET_SPARK_VERSION=0.11.0
+DOTNET_SPARK_VERSION=0.12.1
 SPARK_VERSION=2.4.5
+PROXY="http://localhost:3128"
 ```
 
 Please note, that not all combinations are supported, however.


### PR DESCRIPTION
We now have a variable called `PROXY`, which will be (I think you
guessed...) the proxy address used by the `docker build` command.

Currently, the proxy address is for both HTTP and HTTPS protocols.
Perhaps we should make a distinction in the future.

I also bumped the version of Microsoft.Spark library to the latest
avaiable, which is 0.12.1